### PR TITLE
Fix semicolon

### DIFF
--- a/src/lib/removeRuleLastSemi.ts
+++ b/src/lib/removeRuleLastSemi.ts
@@ -1,0 +1,3 @@
+export function removeRuleLastSemi (str: string): string {
+  return str.replace(/;\s*}/g, '}')
+}

--- a/src/lib/tokenize.ts
+++ b/src/lib/tokenize.ts
@@ -4,6 +4,7 @@ import { isWhitespace } from './utils'
 import { MediaQuery } from './mediaQuery.d'
 import { removeComments } from './removeComments'
 import { removeDuplicates } from './removeDuplicates'
+import { removeRuleLastSemi } from './removeRuleLastSemi'
 
 /**
  * Check if char is skippable because its value does mean nothing in css
@@ -94,9 +95,10 @@ const getRuleValue: GetRuleValueFunction = ({ oldChar, currentRules, newRules })
  * @returns cleaned css string
  */
 export const cleanCss = (css: string): string => {
-  css = removeDuplicates(css, [';', '.', ' '])
-  css = removeComments(css)
-  return css
+  const cssNoDuplicates = removeDuplicates(css, [';', '.', ' '])
+  const cssNoComments = removeComments(cssNoDuplicates)
+  const cssNoLastSemi = removeRuleLastSemi(cssNoComments)
+  return cssNoLastSemi
 }
 
 /**

--- a/tests/lib/removeRuleLastSemi.test.ts
+++ b/tests/lib/removeRuleLastSemi.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { removeRuleLastSemi } from '../../src/lib/removeRuleLastSemi'
+
+describe('removeRuleLastSemi', () => {
+  it('should remove last semicolon', () => {
+    expect(removeRuleLastSemi('{color: black;}')).toBe('{color: black}')
+  })
+
+  it('should not remove seimcolon if not last char of the rule', () => {
+    expect(removeRuleLastSemi('{color: black; background: white;}')).toBe(
+      '{color: black; background: white}'
+    )
+  })
+})


### PR DESCRIPTION
[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://lu.ma/open-source-saturday-torino)

Remove unnecessary semicolon at the end of rule