### PR TITLE
Resolves #81 - Handle transparency in reduceHexColor

### DIFF
--- a/src/lib/optimization.ts
+++ b/src/lib/optimization.ts
@@ -60,7 +60,7 @@ export const isAllSideDifferent = ({
 };
 
 export const reduceHexColor = (color: string): string => {
-	if (color === "") return color;
+	if (color === "" || color.length !== 7 || color[0] !== "#") return color;
 	if (color[1] === color[2] && color[3] === color[4] && color[5] === color[6]) {
 		return `#${color[1]}${color[3]}${color[5]}`;
 	}

--- a/tests/lib/optimization.test.ts
+++ b/tests/lib/optimization.test.ts
@@ -154,6 +154,13 @@ describe("reduceHexColor", () => {
 		expect(reduceHexColor("#12345G")).toBe("#12345G");
 		expect(reduceHexColor("")).toBe("");
 	});
+
+	it("should preserve hex colors with transparency", () => {
+		expect(reduceHexColor("#FFFFFF00")).toBe("#FFFFFF00");
+		expect(reduceHexColor("#00000000")).toBe("#00000000");
+		expect(reduceHexColor("#AABBCC00")).toBe("#AABBCC00");
+		expect(reduceHexColor("#11223300")).toBe("#11223300");
+	});
 });
 
 describe("removeComments", () => {


### PR DESCRIPTION
This pull request makes a small but important improvement to the `reduceHexColor` utility function, ensuring that only valid 7-character hex colors (e.g., `#RRGGBB`) are reduced, and adds tests to confirm correct handling of hex colors with transparency (8-character hex codes).

Enhancements to hex color reduction:

* Updated `reduceHexColor` in `src/lib/optimization.ts` to return the original color string when the input is not a standard 7-character hex color, preventing incorrect reduction of invalid or 8-character (with transparency) hex codes.

Testing improvements:

* Added tests in `tests/lib/optimization.test.ts` to verify that 8-character hex colors (with transparency) are preserved and not reduced by `reduceHexColor`.