### PR TITLE
Quick Win 3: Delete Dead Code in Tokenizer

### DIFF
--- a/src/lib/mediaQuery.ts
+++ b/src/lib/mediaQuery.ts
@@ -29,7 +29,6 @@ export const getMediaQueries = (css: string): MediaQuery[] => {
 		if (firstParenthesis < 0) continue; // Skip if no opening brace found
 
 		let deep = 1;
-		let val = "";
 		const rule = css.slice(index, firstParenthesis);
 		let i = firstParenthesis + 1;
 
@@ -50,11 +49,6 @@ export const getMediaQueries = (css: string): MediaQuery[] => {
 					deep--;
 				}
 
-				// Collect characters for the value
-				if (deep > 0) {
-					val += css[i];
-				}
-
 				// Exit when we reach the closing brace of the media query
 				if (deep === 0) {
 					break;
@@ -66,7 +60,6 @@ export const getMediaQueries = (css: string): MediaQuery[] => {
 
 			mediaQueries.push({
 				rule,
-				val,
 				start: index,
 				end: mediaQueryEnd,
 			});

--- a/src/lib/mediaQueryTypes.ts
+++ b/src/lib/mediaQueryTypes.ts
@@ -1,6 +1,5 @@
 export interface MediaQuery {
 	rule: string;
-	val: string;
 	start: number;
 	end: number;
 }

--- a/tests/lib/mediaQuery.test.ts
+++ b/tests/lib/mediaQuery.test.ts
@@ -126,7 +126,6 @@ describe("getMediaQueries", () => {
 	it("return media queries with comments inside", () => {
 		const rules = getMediaQueries(mediaQueryWithCommentsInside);
 		expect(rules.length).toEqual(1);
-		expect(rules[0].val).not.toContain("/* Another comment */");
 	});
 
 	it("return empty array if no media query", () => {


### PR DESCRIPTION
Fixes #85. In the `getMediaQueries` function, there was a slow string concatenation operation (`val += css[i]`) used to build a string that was never actually used later. Deleted this string concatenation logic and the `val` property from the `MediaQuery` object. All tests pass.