### PR TITLE
Fast-Forward Tokenizer Index over Media Queries

### DIFF
--- a/src/lib/tokenize.ts
+++ b/src/lib/tokenize.ts
@@ -179,20 +179,9 @@ export const tokenize = (css: string, optmizations?: Optimizations): Tokens => {
 			index >= mediaQueries[mediaQueryParsed].start &&
 			index < mediaQueries[mediaQueryParsed].end
 		) {
-			// We're inside a media query
-			if (index === mediaQueries[mediaQueryParsed].end - 1) {
-				// We're at the closing brace
-				oldChar = char;
-				if (char === "}") {
-					mediaQueryParsed++;
-					// Make sure we don't skip the next character after the media query
-					// This is important when a selector immediately follows a media query
-					if (index + 1 < css.length && css[index + 1] === ".") {
-						// Make sure we don't accidentally skip a class selector
-						continue;
-					}
-				}
-			}
+			index = mediaQueries[mediaQueryParsed].end - 1;
+			oldChar = css[index];
+			mediaQueryParsed++;
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #87. Modify the tokenizer to fast-forward the index pointer directly to the end of the media query (`index = mediaQuery.end - 1`) instead of stepping character-by-character, improving performance.