### PR TITLE
fix: correct npx bin path and add exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@gafreax/csscrunch",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Simple CSS Parser to tokenize CSS, merge rules, and optimize it",
-  "main": "dist/src/index.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.cts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
   "scripts": {
     "check": "biome check && vitest test --run && vitest bench --run && tsc --noEmit",
     "prepublish": "pnpm run build",
@@ -22,7 +36,7 @@
   },
   "author": "Gabriele Fontana",
   "bin": {
-    "csscrunch": "dist/src/launch.js"
+    "csscrunch": "dist/launch.cjs"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Fixed the package.json bin path which was pointing to a non-existent file, causing npx to fail. Also added proper exports and bumped version to 1.3.1.