### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -337,7 +337,7 @@ const parsedCSS = compile(cssString);</code></pre>
           <div class="chart-box">
             <iframe src="./benchmark/csscrunch-vs-cleancss.chart.html" title="Throughput Comparison Chart"></iframe>
           </div>
-          <a href="./benchmark/throughput-report.html" class="btn">View Detailed Throughput Report</a>
+          <a href="./benchmark/csscrunch-vs-cleancss.chart.html" class="btn" target="_blank">View Full Chart</a>
         </div>
 
         <div>
@@ -346,7 +346,7 @@ const parsedCSS = compile(cssString);</code></pre>
           <div class="chart-box tall">
             <iframe src="./benchmark/size-report.html" title="Size Comparison Chart"></iframe>
           </div>
-          <a href="./benchmark/size-report.html" class="btn">View Detailed Size Report</a>
+          <a href="./benchmark/size-report.html" class="btn" target="_blank">View Detailed Size Report</a>
         </div>
       </div>
     </section>
@@ -354,7 +354,7 @@ const parsedCSS = compile(cssString);</code></pre>
 
   <footer>
     <p>
-      <a href="https://github.com/gafreax/csscrunch">View CSS Crunch on GitHub</a>
+      <a href="https://github.com/gafreax/csscrunch" target="_blank">View CSS Crunch on GitHub</a>
     </p>
   </footer>
 


### PR DESCRIPTION
Fixed the broken throughput report link and made links open in new tabs.